### PR TITLE
Only chown directories/gosu fluentd when trying to step-down from root to a non-root user

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/fluentd/run.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/fluentd/run.sh
@@ -25,7 +25,8 @@ if [[ -n "$FLUENTD_OPT" ]]; then
 fi
 
 info "** Starting Fluentd **"
-if am_i_root; then
+if am_i_root && [[ "$FLUENTD_DAEMON_USER" != "root" ]]; then
+    info "Switching daemon from root to $FLUENTD_DAEMON_USER..."
     exec gosu "$FLUENTD_DAEMON_USER" "$EXEC" "${args[@]}"
 else
     exec "$EXEC" "${args[@]}"

--- a/1/debian-10/rootfs/opt/bitnami/scripts/fluentd/setup.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/fluentd/setup.sh
@@ -15,8 +15,9 @@ set -o pipefail
 # Load Fluentd environment
 eval "$(fluentd_env)"
 
-# Ensure fluentd user and group exist when running as 'root'
-if am_i_root; then
+if am_i_root && [[ "$FLUENTD_DAEMON_USER" != "root" ]]; then
+    info "Ensuring $FLUENTD_DAEMON_USER:$FLUENTD_DAEMON_GROUP has ownership of required directories..."
+    # Ensure fluentd user and group exist when running as 'root'
     ensure_user_exists "$FLUENTD_DAEMON_USER" "$FLUENTD_DAEMON_GROUP"
 
     # Ensure FLUENTD_DAEMON_USER has directory level permissions for installing fluentd plugins


### PR DESCRIPTION
**Description of the change**

Reduces need for extra Linux capabilities (CAP_CHOWN, CAP_SETUID, CAP_SETGID) when running the daemon as `root` (which is required in some container orchestration environments).

Since one already has to grant the container permissions to run as `root` it would be better if it didn't also require additional capabilities.

**Benefits**

- Allows reduced attack surface area when running fluentd as `root` (e.g in a default AWS EKS AMI environment where the `hostPath` mounts require you to be root to read Docker metadata and log info)
- Simplifies defining `PodSecurityPolicy` for fluentd in a forwarder configuration by avoiding having to couple the `PodSecurityPolicy` too closely to the internal implementation by granting these specific capabilities

**Possible drawbacks**

None known.

I don't believe the intention of the `chown`s or `gosu`s here were to run when you are running both container and process as root - they seem to specifically support stepping down to a different user after the initial setup, but seem irrelevant if you are running the process as `root` anyway.

**Applicable issues**

- fixes #13 

